### PR TITLE
Removing copilot from devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -93,7 +93,6 @@
         "pomdtr.excalidraw-editor",
         "ms-azuretools.vscode-bicep",
         "tamasfe.even-better-toml",
-        "github.copilot",
         // Python specific
         "ms-python.python",
         "ms-python.debugpy",


### PR DESCRIPTION
Since this is a learning environment, Copilot should not be on by default